### PR TITLE
v1.1 +spaceDefaultToTab (4 to arbitrary), Moved into Edit menu, impoved Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 Brackets Tab to space
 =================
 
-A brackets extension to convert tab based identation to space based identation and vice versa.
+A [Brackets](https://github.com/adobe/brackets/) extension to convert tab based identation to space based identation and vice versa.
 
-To install, place the ```tabtospace``` folder inside the ```brackets/src/extensions/user``` folder.
+How to install
+--------------
+
+**Brackets: Menu > File > Extension Manager, [Install from URL...]** and paste ZIP url above.
+
+
+####Or manually
+1. Download ZIP
+2. Unzip in **user** folder in **Brackets > Help > Show Extensions Folder**
+3. Restart Brackets
 
 **Compatible with Brackets Sprint10**
 
@@ -11,6 +20,14 @@ To install, place the ```tabtospace``` folder inside the ```brackets/src/extensi
 Usage
 =====
 
-Simply open a project in Brackets, and select ```Convert indentation to spaces``` or ```Convert indentation to tabs``` from the ```File``` menu.
+Simply open a project in Brackets, and select ```Convert indentation to spaces``` or ```Convert indentation to tabs``` from the ```Edit``` menu.
 
-This will replace tabs with N spaces, and replace each group of N spaces with a tab (N being the tab length defined in the editor, 4 being the default).
+
+This will replace tabs with N spaces, and replace N spaces at the begining of each line with a tab (N being the tab length defined in the editor, 4 being the default).
+
+```Convert 4-space indentation to tabs``` will replace 4 spaces at the begining of each line, regardless of editor defaults.
+
+History
+-------
+v 1.1
++ Convert 4-space indentation to tabs

--- a/main.js
+++ b/main.js
@@ -56,7 +56,7 @@ define(function (require, exports, module) {
         return DEFAULT_TAB_WIDTH;
     }
 
-    
+
     function replaceInDocument(re, textOrFunc) {
         var txt = DocumentManager.getCurrentDocument().getText();
         var txt2 = txt.replace(re, textOrFunc);
@@ -84,17 +84,17 @@ define(function (require, exports, module) {
 
         console.assert(0            === lengthOfIndentation("",       tabWidth));
         console.assert(tabWidth     === lengthOfIndentation("\t",     tabWidth));
-        
+
         console.assert(1            === lengthOfIndentation(" ",      tabWidth));
         console.assert(2            === lengthOfIndentation("  ",     tabWidth));
         console.assert(3            === lengthOfIndentation("   ",    tabWidth));
         console.assert(4            === lengthOfIndentation("    ",   tabWidth));
-        
+
         console.assert(tabWidth + 1 === lengthOfIndentation("\t ",    tabWidth));
         console.assert(tabWidth + 2 === lengthOfIndentation("\t  ",   tabWidth));
         console.assert(tabWidth + 3 === lengthOfIndentation("\t   ",  tabWidth));
         console.assert(tabWidth + 4 === lengthOfIndentation("\t    ", tabWidth));
-        
+
         console.assert(tabWidth     === lengthOfIndentation(" \t",    tabWidth));
         console.assert(tabWidth     === lengthOfIndentation("  \t",   tabWidth));
         console.assert(tabWidth     === lengthOfIndentation("   \t",  tabWidth));
@@ -104,7 +104,7 @@ define(function (require, exports, module) {
 
     function indentationWithLength(length, tabWidth) {
         var indentation = "";
-        
+
         // Use tabs if tabWidth is not undefined, null or 0
         if (tabWidth) {
             while (length >= tabWidth) {
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
                 length -= tabWidth;
             }
         }
-        
+
         while (length > 0) {
             indentation += " ";
             length -= 1;

--- a/main.js
+++ b/main.js
@@ -24,7 +24,10 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
 /*global define, $, brackets, window */
 
-/** extension to convert indentation to tabs or spaces */
+/* https://github.com/davidderaedt/tabtospace-extension
+   extension to convert indentation to tabs or spaces
+   v1.1: + 4-space indentation to tabs */
+
 define(function (require, exports, module) {
     'use strict';
 
@@ -34,13 +37,15 @@ define(function (require, exports, module) {
         Menus           = brackets.getModule("command/Menus");
 
 
-    var TAB2S_COMMAND   = "tabtospace.tabtospace";
-    var S2TAB_COMMAND   = "tabtospace.spacetotab";
-    var TAB2S_MENU_NAME = "Convert indentation to spaces";
-    var S2TAB_MENU_NAME = "Convert indentation to tabs";
-    var DEFAULT_TAB_WIDTH    = 4;
+    var TAB2S_COMMAND    = "tabtospace.tabtospace";
+    var S2TAB_COMMAND    = "tabtospace.spacetotab";
+    var SD2TAB_COMMAND   = "tabtospace.spaceDToTab";
+    var TAB2S_MENU_NAME  = "Convert indentation to spaces";
+    var S2TAB_MENU_NAME  = "Convert indentation to tabs";
+    var SD2TAB_MENU_NAME = "Convert 4-space indentation to tabs";
+    var DEFAULT_TAB_WIDTH = 4;
     var INDENTATION_MATCHER = /^[ \t]+/gm;
-    
+
 
     function getTabWidth() {
         var editor = EditorManager.getCurrentFullEditor();
@@ -50,7 +55,7 @@ define(function (require, exports, module) {
         console.log("Using default tab width");
         return DEFAULT_TAB_WIDTH;
     }
-    
+
     
     function replaceInDocument(re, textOrFunc) {
         var txt = DocumentManager.getCurrentDocument().getText();
@@ -124,8 +129,8 @@ define(function (require, exports, module) {
             console.assert(i === lengthOfIndentation(indentationWithLength(i),           tabWidth));
         }
     }
-    
-    
+
+
     function tabToSpaceReplacer(indentation) {
         var length = lengthOfIndentation(indentation, getTabWidth());
         return indentationWithLength(length);
@@ -141,19 +146,31 @@ define(function (require, exports, module) {
         var length = lengthOfIndentation(indentation, editorTabWidth);
         return indentationWithLength(length, editorTabWidth);
     }
-    
+
     function spaceToTab() {
         replaceInDocument(INDENTATION_MATCHER, spaceToTabReplacer);
     }
 
 
-    CommandManager.register(TAB2S_MENU_NAME, TAB2S_COMMAND, tabToSpace);
-    CommandManager.register(S2TAB_MENU_NAME, S2TAB_COMMAND, spaceToTab);
+    function spaceDefaultToTabReplacer(indentation) {
+        var length = lengthOfIndentation(indentation, DEFAULT_TAB_WIDTH);
+        return indentationWithLength(length, DEFAULT_TAB_WIDTH);
+    }
 
-    var menu = Menus.getMenu(Menus.AppMenuBar.FILE_MENU);
+    function spaceDefaultToTab() {
+        replaceInDocument(INDENTATION_MATCHER, spaceDefaultToTabReplacer);
+    }
+
+
+    CommandManager.register(TAB2S_MENU_NAME,  TAB2S_COMMAND,  tabToSpace);
+    CommandManager.register(S2TAB_MENU_NAME,  S2TAB_COMMAND,  spaceToTab);
+    CommandManager.register(SD2TAB_MENU_NAME, SD2TAB_COMMAND, spaceDefaultToTab);
+
+    var menu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
     menu.addMenuDivider();
     menu.addMenuItem(TAB2S_COMMAND);
     menu.addMenuItem(S2TAB_COMMAND);
+    menu.addMenuItem(SD2TAB_COMMAND);
 
     testLengthOfIndentation();
     testIndentationWithLength();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "title": "Tab To Space",
     "description": "Converts indentation to tabs or spaces.",
     "homepage": "https://github.com/davidderaedt/tabtospace-extension",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "author": "David Deraedt <dderaedt@adobe.com> (http://www.dehats.com)",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
 Moved menu into Edit, where it resides in many other editors.
- spaceDefaultToTab, so the script's DEFAULT_TAB_WIDTH (4) is used to find spaced indents.  Needed since currently, my configured Tab Size is 2, which spaceToTab translates twice as many tabs needed to indent.

Perhaps not the best solution.  TODO: somehow input the expected widths, since the source & desired destinations my be different.  Perhaps reading Brackets' "Tab Size" & "Spaces" values will help (since they have separate settings now), some my want to translate from 4 spaces into 2 spaces.

But this works for me now.
cheers
